### PR TITLE
Fix tmux Keybindings

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -1,8 +1,8 @@
 
 # Options
 set-option -g default-shell /usr/bin/zsh
+set-option -g default-terminal "xterm-screen-256color"
 set-option -g history-limit 10000
-set-window-option -g xterm-keys on
 
 # Keybindings
 bind-key h split-window -h

--- a/.zsh/prompts/jilada.zsh
+++ b/.zsh/prompts/jilada.zsh
@@ -22,7 +22,7 @@ function zle_Line_init zle-keymap-select {
     set_prompt
     zle reset_prompt
 }
-zle -N zle-line-init
+# zle -N zle-line-init
 zle -N zle-keymap-select
 
 function prompt_jilada_setup {


### PR DESCRIPTION
No such shell function `zle-line-init' 
 - Remove zle-line-init because it complains in tmux
 - Remove unnecessary global set options in tmux conf